### PR TITLE
Rewrite keyboard code for KOS API changes.

### DIFF
--- a/engine/platform/dreamcast/in_dc.c
+++ b/engine/platform/dreamcast/in_dc.c
@@ -253,8 +253,8 @@ Processes input events from the keyboard, mouse, and joystick.
 void Platform_RunEvents(void)
 {
     int i;
-    static uint32_t last_buttons, last_msbtn;
-    static kbd_state_t old_kbd;
+    static uint32_t last_msbtn;
+    static kbd_mods_t last_mods = {0};
     static int last_X = 0, last_Y = 0, last_X2 = 0, last_Y2 = 0;
 	maple_device_t *dev = maple_enum_type(0, MAPLE_FUNC_CONTROLLER);
     cont_state_t *cont;
@@ -391,37 +391,41 @@ void Platform_RunEvents(void)
 		
 		if (kbd)
 		{
-			int shiftkeys = kbd->shift_keys ^ old_kbd.shift_keys;
+			uint8_t shiftkeys = kbd->last_modifiers.raw ^ last_mods.raw;
 			
-			if (shiftkeys & (KBD_MOD_LCTRL | KBD_MOD_RCTRL))
+			if (shiftkeys & KBD_MOD_CTRL)
 			{
-				Key_Event(K_CTRL , ((kbd->shift_keys & (KBD_MOD_LCTRL | KBD_MOD_RCTRL)) != 0));
+				Key_Event(K_CTRL , ((kbd->last_modifiers.raw & KBD_MOD_CTRL) != 0));
 			}
 			
-			if (shiftkeys & (KBD_MOD_LSHIFT | KBD_MOD_RSHIFT))
+			if (shiftkeys & KBD_MOD_SHIFT)
 			{
-				Key_Event(K_SHIFT , ((kbd->shift_keys & (KBD_MOD_LSHIFT | KBD_MOD_RSHIFT)) != 0));
+				Key_Event(K_SHIFT , ((kbd->last_modifiers.raw & KBD_MOD_SHIFT) != 0));
 			}
 			
-			if (shiftkeys & (KBD_MOD_LALT | KBD_MOD_RALT))
+			if (shiftkeys & KBD_MOD_ALT)
 			{
-				Key_Event(K_ALT , ((kbd->shift_keys & (KBD_MOD_LALT | KBD_MOD_RALT)) != 0));
+				Key_Event(K_ALT , ((kbd->last_modifiers.raw & KBD_MOD_ALT) != 0));
 			}
 			
 			if (shiftkeys & (KBD_MOD_S1 | KBD_MOD_S2))
 			{
-				Key_Event(K_WIN , ((kbd->shift_keys & (KBD_MOD_S1 | KBD_MOD_S2)) != 0));
+				Key_Event(K_WIN , ((kbd->last_modifiers.raw & (KBD_MOD_S1 | KBD_MOD_S2)) != 0));
 			}
 			
 			for(i = 0; i < sizeof(dc_kbd_map); ++i) 
 			{
-				if(kbd->matrix[i] != old_kbd.matrix[i]) 
+				/* Get the state of key i */
+				key_state_value_t i_state = kbd->key_states[i];
+
+				/* If the state of i changed */
+				if(i_state.is_down ^ i_state.was_down)
 				{
-					if (i == KBD_KEY_PAD_NUMLOCK && kbd->matrix[i])
+					if (i == KBD_KEY_PAD_NUMLOCK && i_state.is_down)
 					{
 						numlock_en ^= 1;
 					}
-					else if (i == KBD_KEY_CAPSLOCK && kbd->matrix[i])
+					else if (i == KBD_KEY_CAPSLOCK && i_state.is_down)
 					{
 						capslock_en ^= 1;
 					}
@@ -430,16 +434,16 @@ void Platform_RunEvents(void)
 
 					if(key) 
 					{
-						Key_Event( key , (kbd->matrix[i] != 0) );
+						Key_Event( key , i_state.is_down );
 						
 						if (numlock_en && i >= KBD_KEY_PAD_1 && i <= KBD_KEY_PAD_PERIOD)
 						{
 							key = dc_kbd_map_numlock[i-KBD_KEY_PAD_1];
 						}
 						
-						if (text_in_en && kbd->matrix[i] && (key >= 32 && key < 127))
+						if (text_in_en && i_state.is_down && (key >= 32 && key < 127))
 						{
-							if( (kbd->shift_keys & (KBD_MOD_LSHIFT | KBD_MOD_RSHIFT)))
+							if( (kbd->last_modifiers.raw & KBD_MOD_SHIFT))
 							{
 								if (i >= KBD_KEY_1 && i <= KBD_KEY_SLASH )
 								{
@@ -463,7 +467,7 @@ void Platform_RunEvents(void)
 					}
 				}
 			}
-			old_kbd = *kbd;
+			last_mods = kbd->last_modifiers;
 		}
 	}
 }


### PR DESCRIPTION
Not 100% sure this will work, am still struggling to get the whole project to build to be able to test it out. There were three key sets of changes needed for the keyboard code:
1) The shift_keys struct member has been renamed and shorter defines allow for testing against both alt/shift/ctrl buttons at once. This set of changes was not strictly needed as shift_keys is still there, but we have deprecated it.
2) The value stored in `state->matrix[i]` has changed. They were meant to be tested against with the `KEY_STATE_PRESSED` / `KEY_STATE_WAS_PRESSED` / `KEY_STATE_NONE` defines, rather than the raw value of 0 for 'none'. Testing using those defines against matrix would still work, but that method is being deprecated, so instead we read from `key_states` (a renamed/retyped union with `matrix`) and test against its members `is_down` and `was_down`. We could test if the key state is `KEY_STATE_CHANGED_UP` or `KEY_STATE_CHANGED_DOWN`, but it seems simpler to just xor the two states to see differences, similar to the comparison that was being made before to determine any change.
3) The last change was that since keys now store the full difference between their previous state and current, it's not needed to keep reference to the full `old_kbd` keyboard state. Now on each loop we only need to track the old modifier buttons state, so that is being copied.

Hopefully the explanation and sample changes can be helpful even if it still needs some other change to be correct.